### PR TITLE
feat: Add pause flag for test-experiments sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Fetch upstream
         run: git fetch upstream
 
+      # Check if experiments are paused
+      - name: Check pause status
+        id: check_pause
+        run: |
+          if [ -f ".pause-experiments" ]; then
+            echo "paused=true" >> $GITHUB_OUTPUT
+            echo "⏸️ Experiments are paused"
+          else
+            echo "paused=false" >> $GITHUB_OUTPUT
+            echo "▶️ Experiments will sync normally"
+          fi
+
       - name: Update main (rebase with auto-conflict resolution)
         run: |
           git checkout main
@@ -40,6 +52,7 @@ jobs:
           git push --force-with-lease origin main
 
       - name: Update test-experiments (rebase with auto-conflict resolution)
+        if: steps.check_pause.outputs.paused == 'false'
         run: |
           git checkout test-experiments
           set +e
@@ -51,6 +64,10 @@ jobs:
           )
           set -e
           git push --force-with-lease origin test-experiments
+
+      - name: Skip test-experiments sync
+        if: steps.check_pause.outputs.paused == 'true'
+        run: echo "⏸️ Experiments paused - skipping test-experiments sync"
 
   notify:
     needs: sync


### PR DESCRIPTION
Add conditional sync control to prevent overwriting active experiments

## Changes Made

### Added Pause Functionality
- Added pause status check for `.pause-experiments` file
- Made test-experiments sync conditional based on pause flag
- Added skip notification when experiments are paused

### Workflow Behavior
- **Main branch**: Always syncs (unchanged)
- **test-experiments branch**: Syncs only when not paused
- **Pause control**: Via `.pause-experiments` file in repository

### Use Case
Allows developers to pause automatic syncing of test-experiments branch during active development to prevent work from being overwritten by upstream changes.

### Control Commands
- Pause: Create `.pause-experiments` file and commit
- Resume: Remove `.pause-experiments` file and commit

This enables safe long-running experiments without daily sync interference.

### Implementation Details
- Modified GitHub Actions workflow to check for pause flag
- Added conditional logic to skip test-experiments sync when paused
- Maintains normal sync behavior for main branch
- Compatible with existing local sync scripts
